### PR TITLE
Fix github actions build issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Dockerhub
         uses: docker/login-action@v3

--- a/Dockerfile-apache
+++ b/Dockerfile-apache
@@ -84,6 +84,9 @@ RUN set -eux; \
     ${PHP_EXTRA_BUILD_DEPS:-} \
   ; export CFLAGS="$PHP_CFLAGS" CPPFLAGS="$PHP_CPPFLAGS" LDFLAGS="$PHP_LDFLAGS" \
   ; \
+  if dpkg --compare-versions ${PHP_VERSION} le 8.2; then \
+    docker-php-ext-configure opcache --disable-opcache-jit; \
+  fi; \
   docker-php-ext-install -j$(nproc) opcache \
     ; \
   docker-php-ext-configure gd --with-jpeg --with-xpm --with-webp --with-freetype --with-avif \

--- a/Dockerfile-apache
+++ b/Dockerfile-apache
@@ -215,6 +215,10 @@ RUN set -eux; \
 #    cd -; \
   docker-php-ext-enable --ini-name 0-docker-php-ext-igbinary.ini igbinary; \
   docker-php-ext-enable --ini-name 0-docker-php-ext-msgpack.ini msgpack; \
+  if dpkg --compare-versions ${PHP_VERSION} lt 8.4; then \
+    docker-php-ext-enable event; \
+    docker-php-ext-enable mcrypt; \
+  fi; \
   cp /usr/bin/envsubst /usr/local/bin/envsubst; \
   apt-mark auto '.*' > /dev/null; \
   [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \

--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -84,6 +84,9 @@ RUN set -eux; \
     ${PHP_EXTRA_BUILD_DEPS:-} \
   ; export CFLAGS="$PHP_CFLAGS" CPPFLAGS="$PHP_CPPFLAGS" LDFLAGS="$PHP_LDFLAGS" \
   ; \
+  if dpkg --compare-versions ${PHP_VERSION} le 8.2; then \
+    docker-php-ext-configure opcache --disable-opcache-jit; \
+  fi; \
   docker-php-ext-install -j$(nproc) opcache \
     ; \
   docker-php-ext-configure gd --with-jpeg --with-xpm --with-webp --with-freetype --with-avif \

--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -215,6 +215,10 @@ RUN set -eux; \
 #    cd -; \
   docker-php-ext-enable --ini-name 0-docker-php-ext-igbinary.ini igbinary; \
   docker-php-ext-enable --ini-name 0-docker-php-ext-msgpack.ini msgpack; \
+  if dpkg --compare-versions ${PHP_VERSION} lt 8.4; then \
+    docker-php-ext-enable event; \
+    docker-php-ext-enable mcrypt; \
+  fi; \
   cp /usr/bin/envsubst /usr/local/bin/envsubst; \
   apt-mark auto '.*' > /dev/null; \
   [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \

--- a/Dockerfile-cli-alpine
+++ b/Dockerfile-cli-alpine
@@ -161,7 +161,7 @@ RUN set -eux; \
     ./configure; \
     make && make test && make install || exit 1; \
     cd -; \
-  if dpkg --compare-versions ${PHP_VERSION} lt 8.4; then \
+  if [ "$(printf '%s\n' "${PHP_VERSION}" "8.4" | sort -V | head -n1)" != "8.4" ]; then \
   pecl install --onlyreqdeps --nobuild event; \
     cd "$(pecl config-get temp_dir)/event"; \
     phpize; \
@@ -201,6 +201,10 @@ RUN set -eux; \
 #    cd -; \
   docker-php-ext-enable --ini-name 0-docker-php-ext-igbinary.ini igbinary; \
   docker-php-ext-enable --ini-name 0-docker-php-ext-msgpack.ini msgpack; \
+  if [ "$(printf '%s\n' "${PHP_VERSION}" "8.4" | sort -V | head -n1)" != "8.4" ]; then \
+    docker-php-ext-enable event; \
+    docker-php-ext-enable mcrypt; \
+  fi; \
   cp /usr/bin/envsubst /usr/local/bin/envsubst; \
   runDeps="$( \
       scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \

--- a/Dockerfile-cli-alpine
+++ b/Dockerfile-cli-alpine
@@ -70,6 +70,9 @@ RUN set -eux; \
     ${PHP_EXTRA_BUILD_DEPS:-} \
   ; export CFLAGS="$PHP_CFLAGS" CPPFLAGS="$PHP_CPPFLAGS" LDFLAGS="$PHP_LDFLAGS" \
   ; \
+  if [ "$(printf '%s\n' "${PHP_VERSION}" "8.3" | sort -V | head -n1)" = "${PHP_VERSION}" ]; then \
+    docker-php-ext-configure opcache --disable-opcache-jit; \
+  fi; \
   docker-php-ext-install -j$(nproc) opcache \
     ; \
   docker-php-ext-configure gd --with-jpeg --with-xpm --with-webp --with-freetype --with-avif \

--- a/Dockerfile-fpm
+++ b/Dockerfile-fpm
@@ -84,6 +84,9 @@ RUN set -eux; \
     ${PHP_EXTRA_BUILD_DEPS:-} \
   ; export CFLAGS="$PHP_CFLAGS" CPPFLAGS="$PHP_CPPFLAGS" LDFLAGS="$PHP_LDFLAGS" \
   ; \
+  if dpkg --compare-versions ${PHP_VERSION} le 8.2; then \
+    docker-php-ext-configure opcache --disable-opcache-jit; \
+  fi; \
   docker-php-ext-install -j$(nproc) opcache \
     ; \
   docker-php-ext-configure gd --with-jpeg --with-xpm --with-webp --with-freetype --with-avif \

--- a/Dockerfile-fpm
+++ b/Dockerfile-fpm
@@ -215,6 +215,10 @@ RUN set -eux; \
 #    cd -; \
   docker-php-ext-enable --ini-name 0-docker-php-ext-igbinary.ini igbinary; \
   docker-php-ext-enable --ini-name 0-docker-php-ext-msgpack.ini msgpack; \
+  if dpkg --compare-versions ${PHP_VERSION} lt 8.4; then \
+    docker-php-ext-enable event; \
+    docker-php-ext-enable mcrypt; \
+  fi; \
   cp /usr/bin/envsubst /usr/local/bin/envsubst; \
   apt-mark auto '.*' > /dev/null; \
   [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \

--- a/Dockerfile-fpm-alpine
+++ b/Dockerfile-fpm-alpine
@@ -161,7 +161,7 @@ RUN set -eux; \
     ./configure; \
     make && make test && make install || exit 1; \
     cd -; \
-  if dpkg --compare-versions ${PHP_VERSION} lt 8.4; then \
+  if [ "$(printf '%s\n' "${PHP_VERSION}" "8.4" | sort -V | head -n1)" != "8.4" ]; then \
   pecl install --onlyreqdeps --nobuild event; \
     cd "$(pecl config-get temp_dir)/event"; \
     phpize; \
@@ -201,6 +201,10 @@ RUN set -eux; \
 #    cd -; \
   docker-php-ext-enable --ini-name 0-docker-php-ext-igbinary.ini igbinary; \
   docker-php-ext-enable --ini-name 0-docker-php-ext-msgpack.ini msgpack; \
+  if [ "$(printf '%s\n' "${PHP_VERSION}" "8.4" | sort -V | head -n1)" != "8.4" ]; then \
+    docker-php-ext-enable event; \
+    docker-php-ext-enable mcrypt; \
+  fi; \
   cp /usr/bin/envsubst /usr/local/bin/envsubst; \
   runDeps="$( \
       scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \

--- a/Dockerfile-fpm-alpine
+++ b/Dockerfile-fpm-alpine
@@ -70,6 +70,9 @@ RUN set -eux; \
     ${PHP_EXTRA_BUILD_DEPS:-} \
   ; export CFLAGS="$PHP_CFLAGS" CPPFLAGS="$PHP_CPPFLAGS" LDFLAGS="$PHP_LDFLAGS" \
   ; \
+  if [ "$(printf '%s\n' "${PHP_VERSION}" "8.3" | sort -V | head -n1)" = "${PHP_VERSION}" ]; then \
+    docker-php-ext-configure opcache --disable-opcache-jit; \
+  fi; \
   docker-php-ext-install -j$(nproc) opcache \
     ; \
   docker-php-ext-configure gd --with-jpeg --with-xpm --with-webp --with-freetype --with-avif \

--- a/Dockerfile-zts
+++ b/Dockerfile-zts
@@ -84,6 +84,9 @@ RUN set -eux; \
     ${PHP_EXTRA_BUILD_DEPS:-} \
   ; export CFLAGS="$PHP_CFLAGS" CPPFLAGS="$PHP_CPPFLAGS" LDFLAGS="$PHP_LDFLAGS" \
   ; \
+  if dpkg --compare-versions ${PHP_VERSION} le 8.2; then \
+    docker-php-ext-configure opcache --disable-opcache-jit; \
+  fi; \
   docker-php-ext-install -j$(nproc) opcache \
     ; \
   docker-php-ext-configure gd --with-jpeg --with-xpm --with-webp --with-freetype --with-avif \

--- a/Dockerfile-zts
+++ b/Dockerfile-zts
@@ -215,6 +215,10 @@ RUN set -eux; \
 #    cd -; \
   docker-php-ext-enable --ini-name 0-docker-php-ext-igbinary.ini igbinary; \
   docker-php-ext-enable --ini-name 0-docker-php-ext-msgpack.ini msgpack; \
+  if dpkg --compare-versions ${PHP_VERSION} lt 8.4; then \
+    docker-php-ext-enable event; \
+    docker-php-ext-enable mcrypt; \
+  fi; \
   cp /usr/bin/envsubst /usr/local/bin/envsubst; \
   apt-mark auto '.*' > /dev/null; \
   [ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \

--- a/Dockerfile-zts-alpine
+++ b/Dockerfile-zts-alpine
@@ -161,7 +161,7 @@ RUN set -eux; \
     ./configure; \
     make && make test && make install || exit 1; \
     cd -; \
-  if dpkg --compare-versions ${PHP_VERSION} lt 8.4; then \
+  if [ "$(printf '%s\n' "${PHP_VERSION}" "8.4" | sort -V | head -n1)" != "8.4" ]; then \
   pecl install --onlyreqdeps --nobuild event; \
     cd "$(pecl config-get temp_dir)/event"; \
     phpize; \
@@ -201,6 +201,10 @@ RUN set -eux; \
 #    cd -; \
   docker-php-ext-enable --ini-name 0-docker-php-ext-igbinary.ini igbinary; \
   docker-php-ext-enable --ini-name 0-docker-php-ext-msgpack.ini msgpack; \
+  if [ "$(printf '%s\n' "${PHP_VERSION}" "8.4" | sort -V | head -n1)" != "8.4" ]; then \
+    docker-php-ext-enable event; \
+    docker-php-ext-enable mcrypt; \
+  fi; \
   cp /usr/bin/envsubst /usr/local/bin/envsubst; \
   runDeps="$( \
       scanelf --needed --nobanner --format '%n#p' --recursive /usr/local \

--- a/Dockerfile-zts-alpine
+++ b/Dockerfile-zts-alpine
@@ -70,6 +70,9 @@ RUN set -eux; \
     ${PHP_EXTRA_BUILD_DEPS:-} \
   ; export CFLAGS="$PHP_CFLAGS" CPPFLAGS="$PHP_CPPFLAGS" LDFLAGS="$PHP_LDFLAGS" \
   ; \
+  if [ "$(printf '%s\n' "${PHP_VERSION}" "8.3" | sort -V | head -n1)" = "${PHP_VERSION}" ]; then \
+    docker-php-ext-configure opcache --disable-opcache-jit; \
+  fi; \
   docker-php-ext-install -j$(nproc) opcache \
     ; \
   docker-php-ext-configure gd --with-jpeg --with-xpm --with-webp --with-freetype --with-avif \


### PR DESCRIPTION
Fixes GitHub Actions build failures by correcting Alpine version comparisons, adding a missing `id` to the buildx step, and conditionally enabling `event` and `mcrypt` PHP extensions.

The previous builds failed because Alpine Dockerfiles incorrectly used `dpkg --compare-versions`, the GitHub Actions workflow referenced a `buildx` step without an `id`, and the `event` and `mcrypt` PHP extensions were installed but not enabled, especially for PHP versions where they are compatible.

---
<a href="https://cursor.com/background-agent?bcId=bc-0e4f84b2-98dd-4534-8675-5da335752886">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0e4f84b2-98dd-4534-8675-5da335752886">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

